### PR TITLE
Add utf8_encode_dict to make it handle unicode strings

### DIFF
--- a/chargebee/http.py
+++ b/chargebee/http.py
@@ -16,6 +16,7 @@ def request(method, url, env, params=None):
     headers = {}
 
     url = env.api_url(url)
+    params = utf8_encode_dict(params)
     if method.lower() in ('get', 'head', 'delete'):
         url = '%s?%s' % (url, compat.urlencode(params))
         payload = None
@@ -65,6 +66,17 @@ def process_response(response, http_code):
 
     return resp_json
 
+def utf8_encode_dict(input):
+    result = {}
+    for key, value in input.iteritems():
+        if isinstance(value, unicode):
+            value = value.encode('utf8')
+        elif isinstance(value, dict):
+            value = utf8_encode_dict(value)
+
+        result[key] = value
+
+    return result
 
 def handle_api_resp_error(http_code, resp_json):
     message = ''


### PR DESCRIPTION
This pull request adds support to be able to have (for example) the customer last_name be

❤☀☆☂☻♞☯☭☢€→☎❄♫✂▷✇♎⇧☮♻⌘⌛☘

When used, this shows up correctly in the chargebee console. Without this pull request, an exception is thrown by urlencode.