### PR TITLE
Excluding the tests folder 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author_email='support@chargebee.com',
     url='https://apidocs.chargebee.com/docs/api?lang=python',
     description='Python wrapper for the ChargeBee Subscription Billing API',
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     package_data={'chargebee': ['ssl/*.crt']},
     install_requires=requires,
     test_suite='tests',


### PR DESCRIPTION
to avoid conflicts when deploying with serverless-python-requirements.  I took out the tests folder from the setup so that it doesn't get installed with the package.