### PR TITLE
Global request mocking capability

### DIFF
--- a/chargebee/__init__.py
+++ b/chargebee/__init__.py
@@ -8,3 +8,5 @@ def configure(api_key, site):
         'api_key': api_key,
         'site': site,
     })
+
+mock = ChargeBee.mock

--- a/chargebee/compat.py
+++ b/chargebee/compat.py
@@ -15,10 +15,10 @@ py_minor_v = sys.version_info[1]
 
 if py_major_v < 3:
     from urllib import urlencode
-    from urlparse import urlparse
+    from urlparse import urlparse, urlsplit, parse_qs
     from urllib2 import urlopen as _urlopen, Request
 elif py_major_v >= 3:
-    from urllib.parse import urlencode, urlparse
+    from urllib.parse import urlencode, urlparse, urlsplit, parse_qs
     from urllib.request import urlopen as _urlopen, Request
 
 
@@ -26,12 +26,12 @@ elif py_major_v >= 3:
 try:
     SSLError = None
     ssl = None
-    
+
     if Environment.chargebee_domain is None:
         HTTPSConnection = object
     else:
         HTTPConnection = object
-            
+
     if py_major_v < 3:
         from httplib import HTTPConnection, HTTPSConnection, HTTPException
     else:

--- a/chargebee/environment.py
+++ b/chargebee/environment.py
@@ -1,3 +1,7 @@
+import re
+from collections import namedtuple
+
+
 class Environment(object):
 
     chargebee_domain = None
@@ -15,3 +19,99 @@ class Environment(object):
 
     def api_url(self, url):
         return self.api_endpoint + url
+
+
+class MockEnvironment(Environment):
+    Request = namedtuple('Request', ['method', 'url_path', 'payload'])
+
+    def __init__(self, **options):
+        params = {
+            'api_key': 'mock-api-key',
+            'site': 'mock-test',
+        }
+        params.update(options)
+        super(MockEnvironment, self).__init__(params)
+
+        self.clear()
+
+    def clear(self):
+        """ Clear any expected and previous requests """
+        self.expecting = []
+        self.requests = []
+
+    def add(self, url_path, response_body, response_status=200, request_method=None):
+        """
+        Add a mock response.
+
+        url_path is the API path after the API version. eg. '/subscriptions/1mkVvvHQiQMbLBBf/cancel'
+            It can also be a regex pattern from re.compile()
+        response_body is the JSON response body to return.
+            It can be a string, a JSON-serializable dict, or a callable which
+            will be called with (url_path, payload, method) and should return a (json_body_string, http_status) tuple.
+        response_status is the HTTP response code to return.
+            This is ignored if response_body is a callable.
+        request_method optional HTTP method to check against the request
+
+        >>> with chargebee.mock() as mock:
+        >>>   mock.add('/subscriptions/1mkVvvHQiQMbLBBf/cancel', {"subscription": {...}})
+        >>>   result = chargebee.Subscription.cancel('1mkVvvHQiQMbLBBf')
+        >>>   subscription = result.subscription
+        >>>   mock.requests
+        [Request(method='POST', url_path='/subscriptions/1mkVvvHQiQMbLBBf/cancel', payload={})]
+        >>>   chargebee.Subscription.list({})
+        AssertionError: No more mock requests left: /subscriptions
+        """
+        self.expecting.append((url_path, request_method, response_body, response_status))
+
+    def request(self, method, url, payload):
+        """
+        Called for each Chargebee request
+
+        Adds the request content to MockEnvironment.requests
+        Matches the next expected request and returns the associated content
+
+        Returns a (json_body_string, http_status) tuple
+        """
+        from chargebee.compat import urlsplit, parse_qs, json
+
+        url_obj = urlsplit(url)
+        try:
+            url_path = url_obj.path.split('/api/%s' % self.API_VERSION)[1]
+        except IndexError:
+            raise ValueError("Request URL (%s) didn't match endpoint %s" % (url, self.api_endpoint))
+
+        # un-encode the body/querystring payload
+        payload = parse_qs(payload or url_obj.query, keep_blank_values=True)
+
+        # save to MockEnvironment.requests
+        self.requests.append(MockEnvironment.Request(method, url_path, payload))
+
+        # check the next expected request
+        try:
+            req_path, req_method, resp_body, resp_status = self.expecting.pop(0)
+        except IndexError:
+            raise AssertionError("No more mock requests left: %s" % url_path)
+
+        # Match the URL path
+        if isinstance(req_path, re._pattern_type):
+            # url_path is a regex
+            if not req_path.match(url_path):
+                raise AssertionError("Request URL %s does not match %s" % (url_path, req_path.pattern))
+        elif req_path != url_path:
+            # url_path is a string
+            raise AssertionError("Request URL %s != %s" % (url_path, req_path))
+
+        # Match any request method
+        if req_method and method != req_method.upper():
+            raise AssertionError("Request Method %s != %s (%s)" % (method, req_method, url_path))
+
+        # Return the response
+        if callable(resp_body):
+            # response_body is a callable, use it to generate the response
+            return resp_body(url_path, payload, method)
+        elif isinstance(resp_body, (dict, list, tuple)):
+            # response body is a dict/sequence, JSON-encode it
+            return (json.dumps(resp_body), resp_status)
+        else:
+            # string body
+            return (resp_body, resp_status)

--- a/chargebee/main.py
+++ b/chargebee/main.py
@@ -1,6 +1,7 @@
 import os.path
+from contextlib import contextmanager
 
-from chargebee.environment import Environment
+from chargebee.environment import Environment, MockEnvironment
 
 
 class ChargeBee(object):
@@ -13,3 +14,19 @@ class ChargeBee(object):
     @classmethod
     def configure(cls, options):
         cls.default_env = Environment(options)
+
+    @classmethod
+    @contextmanager
+    def mock(cls, **options):
+        """
+        Context manager for unit testing environments.
+        This changes the default environment, so saves passing custom environments around.
+
+        See MockEnvironment for more details & example usage.
+        """
+        prev_env = cls.default_env
+        try:
+            cls.default_env = MockEnvironment(**options)
+            yield cls.default_env
+        finally:
+            cls.default_env = prev_env


### PR DESCRIPTION
Adds the ability to mock requests relatively easily for unit testing without actually hitting the Chargebee API.

Usage example:
```python
>>> with chargebee.mock() as mock:
>>>    # add an expected request and its response data
>>>    # can do this multiple times
>>>    mock.add(
>>>      '/subscriptions/1mkVvvHQiQMbLBBf/cancel',
>>>      {"subscription": {"id": "1mkVvvHQiQMbLBBf", "status": "cancelled", ...}}
>>>    )
>>>    result = chargebee.Subscription.cancel('1mkVvvHQiQMbLBBf')
>>>    result.subscription.status
'cancelled'
>>> 
>>>    # get most recent request data
>>>   mock.requests[-1]
[Request(method='POST', url_path='/subscriptions/1mkVvvHQiQMbLBBf/cancel', payload={})]
>>>
>>>   # error is raised if unexpected API call is made
>>>   chargebee.Subscription.list({})
AssertionError: No more mock requests left: /subscriptions
```

Assertion errors are raised if:
- a request is received and none is expected
- the URL path doesn't match the next expected request
- (optional) the HTTP method doesn't match expected request

Other features:
- URL path to match can be a compiled regex (eg. `mock.add(re.compile(r'/subscriptions/.*/cancel'), ...)`)
- Response bodies can be JSON strings or JSON-serialisable dicts
- To simulate error responses, pass a status code to `mock.add()`
- Response bodies can be a callable used to generate the response (eg. `mock.add('/subscriptions', list_subs_func)`), which can also be used to generate socket/etc exceptions.
