### PR TITLE
Fix ImportWarning on python 2 due to missing absolute_import

### DIFF
--- a/chargebee/compat.py
+++ b/chargebee/compat.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 
 from chargebee.main import Environment
 


### PR DESCRIPTION
This import warning appears on python 2.7 when you configure logging to show it:

```
venv/local/lib/python2.7/site-packages/chargebee/compat.py:40: ImportWarning: Not importing directory 'venv/local/lib/python2.7/site-packages/chargebee/ssl': missing __init__.py
```

This PR fixes the issue.