### PR TITLE
Fix the order of lists when serialized in a request

### DIFF
--- a/chargebee/util.py
+++ b/chargebee/util.py
@@ -1,8 +1,9 @@
 from chargebee import compat
+from collections import OrderedDict
 
 def serialize(value, prefix=None, idx=None):
 
-    serialized = {}
+    serialized = OrderedDict()
 
     if isinstance(value, dict):
         for k, v in list(value.items()):


### PR DESCRIPTION
Without this, when multiple addons are added on a subscription, the order is not guaranteed to be the same on chargebee's side.

The fix was suggested by chargebee support.