### PR TITLE
Use modern ssl wrapper with SNI support.

### DIFF
--- a/chargebee/compat.py
+++ b/chargebee/compat.py
@@ -63,6 +63,13 @@ class VerifiedHTTPSConnection(HTTPSConnection):
 
         # Wrap socket using verification with the root certs in
         # trusted_root_certs
+
+        # Use modern SSL wrapper when available
+        if hasattr(ssl, 'create_default_context'):
+            ctx = ssl.create_default_context()
+            self.sock = ctx.wrap_socket(sock, server_hostname=self.host)
+            return
+
         self.sock = ssl.wrap_socket(sock, cert_reqs=self.cert_reqs, ca_certs=self.ca_certs)
 
         if self.ca_certs:


### PR DESCRIPTION
This is needed to run the Chargebee client inside recent versions of
Docker desktop on Mac, as that docker version includes a built-in
proxy that only passes through connections with SNI.

Note that this also no longer uses the (outdated) included list of
certificates.