### PR TITLE
Fix AttributeError: module 'chargebee' has no attribute 'Usage'

### DIFF
--- a/chargebee/models/__init__.py
+++ b/chargebee/models/__init__.py
@@ -40,3 +40,4 @@ from chargebee.models.quote import Quote
 from chargebee.models.content import Content
 from chargebee.models.hierarchy import Hierarchy
 from chargebee.models.payment_intent import PaymentIntent
+from chargebee.models.usage import Usage


### PR DESCRIPTION
init was missing the usage model so unable to access that attribute, this fixes that

https://github.com/chargebee/chargebee-python/issues/40