### PR TITLE
Fix serialization of list 

### DIFF
--- a/chargebee/util.py
+++ b/chargebee/util.py
@@ -17,12 +17,8 @@ def serialize(value, prefix=None, idx=None):
                     else:
                         arrayContainsValue = True
                 if arrayContainsValue == True:
-                    key = ''.join([
-                        prefix or '',
-                        '[%s]' % k if prefix is not None else k,
-                        '[%s]' % idx if idx is not None else '',
-                    ])
-                    serialized.update({key: get_val(v)})
+                    for i1, v1 in enumerate(v):
+                        serialized.update(serialize(v1, k, i1))
             else:
                 key = ''.join([
                     prefix or '',

--- a/tests/util.py
+++ b/tests/util.py
@@ -25,7 +25,8 @@ class UtilTest(unittest.TestCase):
                 'expiry_month': '1',
                 'expiry_year': '2024',
                 'cvv': '007',
-            }
+            },
+            'coupon_ids': ["coupon_1", "coupon_2"]
         }
 
         after = {
@@ -40,6 +41,8 @@ class UtilTest(unittest.TestCase):
             'card[expiry_month]': '1',
             'card[expiry_year]': '2024',
             'card[cvv]': '007',
+            'coupon_ids[0]': 'coupon_1',
+            'coupon_ids[1]': 'coupon_2',
         }
 
         self.assertEqual(after, util.serialize(before))


### PR DESCRIPTION
Hi, the changes made in the 2.13.0 version, broke the serialization of the list with primitive strings. 

```
from chargebee import util

result = util.serialize({"coupon_ids": ["test_1", "test_2"]})
```

Chargebee==2.12.1
`result is OrderedDict([('coupon_ids[0]', 'test_1'), ('coupon_ids[1]', 'test_2')])`

Chargebee==2.13.0
`result is OrderedDict([('coupon_ids', ['test_1', 'test_2'])])`

Based on https://apidocs.chargebee.com/docs/api/subscriptions?prod_cat_ver=1#remove_coupons 
The previous result was valid.

I hope my change doesn't introduce another bug. 
