### PR TITLE
Fix Exception re-raising in models/events.py

### DIFF
--- a/chargebee/models/event.py
+++ b/chargebee/models/event.py
@@ -22,7 +22,7 @@ class Event(Model):
         try:
             webhook_data = json.loads(json_data)
         except (TypeError, ValueError) as ex:
-            raise Exception("The passed json_data is not JSON formatted . " + ex.message)
+            raise Exception("The passed json_data is not JSON formatted . {}".format(str(ex)))
         
         api_version = webhook_data.get('api_version', None)
         env_version = Environment.API_VERSION


### PR DESCRIPTION
Exceptions do not have message attribute in Python 3.

See [PEP-352](https://peps.python.org/pep-0352/)

Also, and this is my opinion, it doesn't offer any value to re-raise the JSON decode error as something else. I would propose this change too:

```diff
-try:
-    webhook_data = json.loads(json_data)
-except (TypeError, ValueError) as ex:
-     raise Exception("The passed json_data is not JSON formatted . {}".format(str(ex)))
+webhook_data = json.loads(json_data)
```