### PR TITLE
add mypy support

### DIFF
--- a/chargebee/__init__.py
+++ b/chargebee/__init__.py
@@ -7,4 +7,530 @@ from chargebee.api_error import (
 )
 from chargebee.filters import Filters
 from chargebee.main import Chargebee
-from chargebee.models import *
+
+from chargebee.models.enums import (
+    AccountHolderType,
+    AccountReceivablesHandling,
+    AccountType,
+    Action,
+    ApiVersion,
+    ApplyOn,
+    AutoCollection,
+    AvalaraSaleType,
+    BillingAlignmentMode,
+    BillingDateMode,
+    BillingDayOfWeekMode,
+    BillingPeriodUnit,
+    BillingStartOption,
+    CancelOption,
+    Category,
+    ChangeOption,
+    Channel,
+    ChargeModel,
+    ChargeOnEvent,
+    ChargeOnOption,
+    ChargebeeResponseSchemaType,
+    ChargesHandling,
+    ContractTermCancelOption,
+    CreditOptionForCurrentTermCharges,
+    CreditType,
+    CustomerType,
+    DedupeOption,
+    DirectDebitScheme,
+    DiscountType,
+    DispositionType,
+    DunningType,
+    DurationType,
+    EcheckType,
+    EinvoicingMethod,
+    EndScheduleOn,
+    EntityCode,
+    EntityType,
+    EventName,
+    EventType,
+    ExcludeTaxType,
+    ExportType,
+    FreePeriodUnit,
+    FriendOfferType,
+    Gateway,
+    HierarchyOperationType,
+    InvoiceDunningHandling,
+    ItemType,
+    Layout,
+    NotifyReferralSystem,
+    OfflinePaymentMethod,
+    OnEvent,
+    Operation,
+    OperationType,
+    PauseOption,
+    PaymentInitiator,
+    PaymentMethod,
+    PaymentMethodSavePolicy,
+    PaymentMethodType,
+    PaymentVoucherType,
+    PeriodUnit,
+    PriceType,
+    PricingModel,
+    PricingType,
+    ProductCatalogVersion,
+    ProrationType,
+    ReferralSystem,
+    ReferrerRewardType,
+    RefundableCreditsHandling,
+    ReportBy,
+    ResumeOption,
+    RetryEngine,
+    Role,
+    ScheduleType,
+    Source,
+    TaxExemptReason,
+    TaxJurisType,
+    TaxOverrideReason,
+    Taxability,
+    TaxjarExemptionCategory,
+    TrialEndAction,
+    Type,
+    UnbilledChargesHandling,
+    UnbilledChargesOption,
+    UnpaidInvoicesHandling,
+    UsageAccumulationResetFrequency,
+    ValidationStatus,
+    VoucherType,
+    ChargeOn,
+)
+
+from chargebee.models.addon.operations import Addon
+
+from chargebee.models.address.operations import Address
+
+from chargebee.models.advance_invoice_schedule.operations import AdvanceInvoiceSchedule
+
+from chargebee.models.attached_item.operations import AttachedItem
+
+from chargebee.models.attribute.operations import Attribute
+
+from chargebee.models.billing_configuration.operations import BillingConfiguration
+
+from chargebee.models.brand.operations import Brand
+
+from chargebee.models.business_entity.operations import BusinessEntity
+
+from chargebee.models.business_entity_transfer.operations import BusinessEntityTransfer
+
+from chargebee.models.card.operations import Card
+
+from chargebee.models.comment.operations import Comment
+
+from chargebee.models.configuration.operations import Configuration
+
+from chargebee.models.contact.operations import Contact
+
+from chargebee.models.contract_term.operations import ContractTerm
+
+from chargebee.models.coupon.operations import Coupon
+
+from chargebee.models.coupon_code.operations import CouponCode
+
+from chargebee.models.coupon_set.operations import CouponSet
+
+from chargebee.models.credit_note.operations import CreditNote
+
+from chargebee.models.credit_note_estimate.operations import CreditNoteEstimate
+
+from chargebee.models.currency.operations import Currency
+
+from chargebee.models.customer.operations import Customer
+
+from chargebee.models.customer_entitlement.operations import CustomerEntitlement
+
+from chargebee.models.differential_price.operations import DifferentialPrice
+
+from chargebee.models.discount.operations import Discount
+
+from chargebee.models.download.operations import Download
+
+from chargebee.models.einvoice.operations import Einvoice
+
+from chargebee.models.entitlement.operations import Entitlement
+
+from chargebee.models.entitlement_override.operations import EntitlementOverride
+
+from chargebee.models.estimate.operations import Estimate
+
+from chargebee.models.event.operations import Event
+
+from chargebee.models.export.operations import Export
+
+from chargebee.models.feature.operations import Feature
+
+from chargebee.models.gateway_error_detail.operations import GatewayErrorDetail
+
+from chargebee.models.gift.operations import Gift
+
+from chargebee.models.hierarchy.operations import Hierarchy
+
+from chargebee.models.hosted_page.operations import HostedPage
+
+from chargebee.models.impacted_customer.operations import ImpactedCustomer
+
+from chargebee.models.impacted_item.operations import ImpactedItem
+
+from chargebee.models.impacted_item_price.operations import ImpactedItemPrice
+
+from chargebee.models.impacted_subscription.operations import ImpactedSubscription
+
+from chargebee.models.in_app_subscription.operations import InAppSubscription
+
+from chargebee.models.invoice.operations import Invoice
+
+from chargebee.models.invoice_estimate.operations import InvoiceEstimate
+
+from chargebee.models.item.operations import Item
+
+from chargebee.models.item_entitlement.operations import ItemEntitlement
+
+from chargebee.models.item_family.operations import ItemFamily
+
+from chargebee.models.item_price.operations import ItemPrice
+
+from chargebee.models.metadata.operations import Metadata
+
+from chargebee.models.offer_event.operations import OfferEvent
+
+from chargebee.models.offer_fulfillment.operations import OfferFulfillment
+
+from chargebee.models.omnichannel_one_time_order.operations import (
+    OmnichannelOneTimeOrder,
+)
+
+from chargebee.models.omnichannel_one_time_order_item.operations import (
+    OmnichannelOneTimeOrderItem,
+)
+
+from chargebee.models.omnichannel_subscription.operations import OmnichannelSubscription
+
+from chargebee.models.omnichannel_subscription_item.operations import (
+    OmnichannelSubscriptionItem,
+)
+
+from chargebee.models.omnichannel_subscription_item_offer.operations import (
+    OmnichannelSubscriptionItemOffer,
+)
+
+from chargebee.models.omnichannel_subscription_item_scheduled_change.operations import (
+    OmnichannelSubscriptionItemScheduledChange,
+)
+
+from chargebee.models.omnichannel_transaction.operations import OmnichannelTransaction
+
+from chargebee.models.order.operations import Order
+
+from chargebee.models.payment_intent.operations import PaymentIntent
+
+from chargebee.models.payment_reference_number.operations import PaymentReferenceNumber
+
+from chargebee.models.payment_schedule.operations import PaymentSchedule
+
+from chargebee.models.payment_schedule_estimate.operations import (
+    PaymentScheduleEstimate,
+)
+
+from chargebee.models.payment_schedule_scheme.operations import PaymentScheduleScheme
+
+from chargebee.models.payment_source.operations import PaymentSource
+
+from chargebee.models.payment_voucher.operations import PaymentVoucher
+
+from chargebee.models.personalized_offer.operations import PersonalizedOffer
+
+from chargebee.models.plan.operations import Plan
+
+from chargebee.models.portal_session.operations import PortalSession
+
+from chargebee.models.price_variant.operations import PriceVariant
+
+from chargebee.models.pricing_page_session.operations import PricingPageSession
+
+from chargebee.models.promotional_credit.operations import PromotionalCredit
+
+from chargebee.models.purchase.operations import Purchase
+
+from chargebee.models.quote.operations import Quote
+
+from chargebee.models.quote_line_group.operations import QuoteLineGroup
+
+from chargebee.models.quoted_charge.operations import QuotedCharge
+
+from chargebee.models.quoted_delta_ramp.operations import QuotedDeltaRamp
+
+from chargebee.models.quoted_ramp.operations import QuotedRamp
+
+from chargebee.models.quoted_subscription.operations import QuotedSubscription
+
+from chargebee.models.ramp.operations import Ramp
+
+from chargebee.models.recorded_purchase.operations import RecordedPurchase
+
+from chargebee.models.resource_migration.operations import ResourceMigration
+
+from chargebee.models.rule.operations import Rule
+
+from chargebee.models.site_migration_detail.operations import SiteMigrationDetail
+
+from chargebee.models.subscription.operations import Subscription
+
+from chargebee.models.subscription_entitlement.operations import SubscriptionEntitlement
+
+from chargebee.models.subscription_entitlements_created_detail.operations import (
+    SubscriptionEntitlementsCreatedDetail,
+)
+
+from chargebee.models.subscription_entitlements_updated_detail.operations import (
+    SubscriptionEntitlementsUpdatedDetail,
+)
+
+from chargebee.models.subscription_estimate.operations import SubscriptionEstimate
+
+from chargebee.models.tax_withheld.operations import TaxWithheld
+
+from chargebee.models.third_party_payment_method.operations import (
+    ThirdPartyPaymentMethod,
+)
+
+from chargebee.models.time_machine.operations import TimeMachine
+
+from chargebee.models.token.operations import Token
+
+from chargebee.models.transaction.operations import Transaction
+
+from chargebee.models.unbilled_charge.operations import UnbilledCharge
+
+from chargebee.models.usage.operations import Usage
+
+from chargebee.models.usage_event.operations import UsageEvent
+
+from chargebee.models.usage_file.operations import UsageFile
+
+from chargebee.models.virtual_bank_account.operations import VirtualBankAccount
+
+from chargebee.models.webhook_endpoint.operations import WebhookEndpoint
+
+__all__ = [
+    'APIError',
+    'AccountHolderType',
+    'AccountReceivablesHandling',
+    'AccountType',
+    'Action',
+    'Addon',
+    'Address',
+    'AdvanceInvoiceSchedule',
+    'ApiVersion',
+    'ApplyOn',
+    'AttachedItem',
+    'Attribute',
+    'AutoCollection',
+    'AvalaraSaleType',
+    'BillingAlignmentMode',
+    'BillingConfiguration',
+    'BillingDateMode',
+    'BillingDayOfWeekMode',
+    'BillingPeriodUnit',
+    'BillingStartOption',
+    'Brand',
+    'BusinessEntity',
+    'BusinessEntityTransfer',
+    'CancelOption',
+    'Card',
+    'Category',
+    'ChangeOption',
+    'Channel',
+    'ChargeModel',
+    'ChargeOn',
+    'ChargeOnEvent',
+    'ChargeOnOption',
+    'Chargebee',
+    'ChargebeeResponseSchemaType',
+    'ChargesHandling',
+    'Comment',
+    'Configuration',
+    'Contact',
+    'ContractTerm',
+    'ContractTermCancelOption',
+    'Coupon',
+    'CouponCode',
+    'CouponSet',
+    'CreditNote',
+    'CreditNoteEstimate',
+    'CreditOptionForCurrentTermCharges',
+    'CreditType',
+    'Currency',
+    'Customer',
+    'CustomerEntitlement',
+    'CustomerType',
+    'DedupeOption',
+    'DifferentialPrice',
+    'DirectDebitScheme',
+    'Discount',
+    'DiscountType',
+    'DispositionType',
+    'Download',
+    'DunningType',
+    'DurationType',
+    'EcheckType',
+    'Einvoice',
+    'EinvoicingMethod',
+    'EndScheduleOn',
+    'Entitlement',
+    'EntitlementOverride',
+    'EntityCode',
+    'EntityType',
+    'Estimate',
+    'Event',
+    'EventName',
+    'EventType',
+    'ExcludeTaxType',
+    'Export',
+    'ExportType',
+    'Feature',
+    'Filters',
+    'FreePeriodUnit',
+    'FriendOfferType',
+    'Gateway',
+    'GatewayErrorDetail',
+    'Gift',
+    'Hierarchy',
+    'HierarchyOperationType',
+    'HostedPage',
+    'ImpactedCustomer',
+    'ImpactedItem',
+    'ImpactedItemPrice',
+    'ImpactedSubscription',
+    'InAppSubscription',
+    'InvalidRequestError',
+    'Invoice',
+    'InvoiceDunningHandling',
+    'InvoiceEstimate',
+    'Item',
+    'ItemEntitlement',
+    'ItemFamily',
+    'ItemPrice',
+    'ItemType',
+    'Layout',
+    'Metadata',
+    'NotifyReferralSystem',
+    'OfferEvent',
+    'OfferFulfillment',
+    'OfflinePaymentMethod',
+    'OmnichannelOneTimeOrder',
+    'OmnichannelOneTimeOrderItem',
+    'OmnichannelSubscription',
+    'OmnichannelSubscriptionItem',
+    'OmnichannelSubscriptionItemOffer',
+    'OmnichannelSubscriptionItemScheduledChange',
+    'OmnichannelTransaction',
+    'OnEvent',
+    'Operation',
+    'OperationFailedError',
+    'OperationType',
+    'Order',
+    'PauseOption',
+    'PaymentError',
+    'PaymentInitiator',
+    'PaymentIntent',
+    'PaymentMethod',
+    'PaymentMethodSavePolicy',
+    'PaymentMethodType',
+    'PaymentReferenceNumber',
+    'PaymentSchedule',
+    'PaymentScheduleEstimate',
+    'PaymentScheduleScheme',
+    'PaymentSource',
+    'PaymentVoucher',
+    'PaymentVoucherType',
+    'PeriodUnit',
+    'PersonalizedOffer',
+    'Plan',
+    'PortalSession',
+    'PriceType',
+    'PriceVariant',
+    'PricingModel',
+    'PricingPageSession',
+    'PricingType',
+    'ProductCatalogVersion',
+    'PromotionalCredit',
+    'ProrationType',
+    'Purchase',
+    'Quote',
+    'QuoteLineGroup',
+    'QuotedCharge',
+    'QuotedDeltaRamp',
+    'QuotedRamp',
+    'QuotedSubscription',
+    'Ramp',
+    'RecordedPurchase',
+    'ReferralSystem',
+    'ReferrerRewardType',
+    'RefundableCreditsHandling',
+    'ReportBy',
+    'ResourceMigration',
+    'ResumeOption',
+    'RetryEngine',
+    'Role',
+    'Rule',
+    'ScheduleType',
+    'SiteMigrationDetail',
+    'Source',
+    'Subscription',
+    'SubscriptionEntitlement',
+    'SubscriptionEntitlementsCreatedDetail',
+    'SubscriptionEntitlementsUpdatedDetail',
+    'SubscriptionEstimate',
+    'TaxExemptReason',
+    'TaxJurisType',
+    'TaxOverrideReason',
+    'TaxWithheld',
+    'Taxability',
+    'TaxjarExemptionCategory',
+    'ThirdPartyPaymentMethod',
+    'TimeMachine',
+    'Token',
+    'Transaction',
+    'TrialEndAction',
+    'Type',
+    'UbbBatchIngestionInvalidRequestError',
+    'UnbilledCharge',
+    'UnbilledChargesHandling',
+    'UnbilledChargesOption',
+    'UnpaidInvoicesHandling',
+    'Usage',
+    'UsageAccumulationResetFrequency',
+    'UsageEvent',
+    'UsageFile',
+    'ValidationStatus',
+    'VirtualBankAccount',
+    'VoucherType',
+    'WebhookEndpoint',
+    '__builtins__',
+    '__cached__',
+    '__doc__',
+    '__file__',
+    '__loader__',
+    '__name__',
+    '__package__',
+    '__path__',
+    '__spec__',
+    'api_error',
+    'compat',
+    'environment',
+    'filters',
+    'http_request',
+    'main',
+    'model',
+    'models',
+    'request',
+    'response',
+    'responses',
+    'retry_config',
+    'util',
+    'version',
+]


### PR DESCRIPTION
* Added `chargebee/py.typed`
* Copy/pasted the import statements from `chargebee/models.py to __init__.py`
* Added all actually imported items to `__all__`.

This avoids the following errors & problems:

* Module "chargebee" does not explicitly export attribute "Chargebee"
* Skipping analyzing "chargebee": module is installed, but missing library stubs or py.typed marker
* All chargebee results types being interpreted as `Any` despite more rich information being available.

Since there were already quite a few typing annotations this actually brings chargebee into a "works for me" status w.r.t. mypy usage.